### PR TITLE
KernelConfig: Remove BUILD_KERNEL override.

### DIFF
--- a/KernelConfig.mk
+++ b/KernelConfig.mk
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUILD_KERNEL := false
-
 ifeq ($(BUILD_KERNEL),false)
 
 LOCAL_KERNEL := $(KERNEL_PATH)/common-kernel/kernel-dtb-$(TARGET_DEVICE)

--- a/KernelConfig.mk
+++ b/KernelConfig.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ifeq ($(BUILD_KERNEL),false)
+ifneq ($(BUILD_KERNEL),true)
 
 LOCAL_KERNEL := $(KERNEL_PATH)/common-kernel/kernel-dtb-$(TARGET_DEVICE)
 


### PR DESCRIPTION
This override looks like a debug variable. It should actually be set from the respective common Makefile, otherwise the ifeq below and in other files serve no purpose.